### PR TITLE
- keep track of parent refs better

### DIFF
--- a/expander_test.go
+++ b/expander_test.go
@@ -152,7 +152,7 @@ func TestCircularRefsExpansion(t *testing.T) {
 	schema := spec.Definitions["car"]
 
 	assert.NotPanics(t, func() {
-		err = expandSchema(&schema, "#/definitions/car", resolver)
+		err = expandSchema(&schema, []string{"#/definitions/car"}, resolver)
 		assert.NoError(t, err)
 	}, "Calling expand schema with circular refs, should not panic!")
 }
@@ -201,7 +201,7 @@ func TestItemsExpansion(t *testing.T) {
 	assert.NotEmpty(t, oldBrand.Items.Schema.Ref.String())
 	assert.NotEqual(t, spec.Definitions["brand"], oldBrand)
 
-	err = expandSchema(&schema, "#/definitions/car", resolver)
+	err = expandSchema(&schema, []string{"#/definitions/car"}, resolver)
 	assert.NoError(t, err)
 
 	newBrand := schema.Properties["brand"]
@@ -211,23 +211,23 @@ func TestItemsExpansion(t *testing.T) {
 	schema = spec.Definitions["truck"]
 	assert.NotEmpty(t, schema.Items.Schema.Ref.String())
 
-	err = expandSchema(&schema, "#/definitions/truck", resolver)
+	err = expandSchema(&schema, []string{"#/definitions/truck"}, resolver)
 	assert.NoError(t, err)
 	assert.Empty(t, schema.Items.Schema.Ref.String())
 	assert.Equal(t, spec.Definitions["car"], *schema.Items.Schema)
 
 	sch := new(Schema)
-	err = expandSchema(sch, "", resolver)
+	err = expandSchema(sch, []string{""}, resolver)
 	assert.NoError(t, err)
 
 	schema = spec.Definitions["batch"]
-	err = expandSchema(&schema, "#/definitions/batch", resolver)
+	err = expandSchema(&schema, []string{"#/definitions/batch"}, resolver)
 	assert.NoError(t, err)
 	assert.Empty(t, schema.Items.Schema.Items.Schema.Ref.String())
 	assert.Equal(t, *schema.Items.Schema.Items.Schema, spec.Definitions["brand"])
 
 	schema = spec.Definitions["batch2"]
-	err = expandSchema(&schema, "#/definitions/batch2", resolver)
+	err = expandSchema(&schema, []string{"#/definitions/batch2"}, resolver)
 	assert.NoError(t, err)
 	assert.Empty(t, schema.Items.Schemas[0].Items.Schema.Ref.String())
 	assert.Empty(t, schema.Items.Schemas[1].Items.Schema.Ref.String())
@@ -235,7 +235,7 @@ func TestItemsExpansion(t *testing.T) {
 	assert.Equal(t, *schema.Items.Schemas[1].Items.Schema, spec.Definitions["tag"])
 
 	schema = spec.Definitions["allofBoth"]
-	err = expandSchema(&schema, "#/definitions/allofBoth", resolver)
+	err = expandSchema(&schema, []string{"#/definitions/allofBoth"}, resolver)
 	assert.NoError(t, err)
 	assert.Empty(t, schema.AllOf[0].Items.Schema.Ref.String())
 	assert.Empty(t, schema.AllOf[1].Items.Schema.Ref.String())
@@ -243,7 +243,7 @@ func TestItemsExpansion(t *testing.T) {
 	assert.Equal(t, *schema.AllOf[1].Items.Schema, spec.Definitions["tag"])
 
 	schema = spec.Definitions["anyofBoth"]
-	err = expandSchema(&schema, "#/definitions/anyofBoth", resolver)
+	err = expandSchema(&schema, []string{"#/definitions/anyofBoth"}, resolver)
 	assert.NoError(t, err)
 	assert.Empty(t, schema.AnyOf[0].Items.Schema.Ref.String())
 	assert.Empty(t, schema.AnyOf[1].Items.Schema.Ref.String())
@@ -251,7 +251,7 @@ func TestItemsExpansion(t *testing.T) {
 	assert.Equal(t, *schema.AnyOf[1].Items.Schema, spec.Definitions["tag"])
 
 	schema = spec.Definitions["oneofBoth"]
-	err = expandSchema(&schema, "#/definitions/oneofBoth", resolver)
+	err = expandSchema(&schema, []string{"#/definitions/oneofBoth"}, resolver)
 	assert.NoError(t, err)
 	assert.Empty(t, schema.OneOf[0].Items.Schema.Ref.String())
 	assert.Empty(t, schema.OneOf[1].Items.Schema.Ref.String())
@@ -259,39 +259,39 @@ func TestItemsExpansion(t *testing.T) {
 	assert.Equal(t, *schema.OneOf[1].Items.Schema, spec.Definitions["tag"])
 
 	schema = spec.Definitions["notSomething"]
-	err = expandSchema(&schema, "#/definitions/notSomething", resolver)
+	err = expandSchema(&schema, []string{"#/definitions/notSomething"}, resolver)
 	assert.NoError(t, err)
 	assert.Empty(t, schema.Not.Items.Schema.Ref.String())
 	assert.Equal(t, *schema.Not.Items.Schema, spec.Definitions["tag"])
 
 	schema = spec.Definitions["withAdditional"]
-	err = expandSchema(&schema, "#/definitions/withAdditional", resolver)
+	err = expandSchema(&schema, []string{"#/definitions/withAdditional"}, resolver)
 	assert.NoError(t, err)
 	assert.Empty(t, schema.AdditionalProperties.Schema.Items.Schema.Ref.String())
 	assert.Equal(t, *schema.AdditionalProperties.Schema.Items.Schema, spec.Definitions["tag"])
 
 	schema = spec.Definitions["withAdditionalItems"]
-	err = expandSchema(&schema, "#/definitions/withAdditionalItems", resolver)
+	err = expandSchema(&schema, []string{"#/definitions/withAdditionalItems"}, resolver)
 	assert.NoError(t, err)
 	assert.Empty(t, schema.AdditionalItems.Schema.Items.Schema.Ref.String())
 	assert.Equal(t, *schema.AdditionalItems.Schema.Items.Schema, spec.Definitions["tag"])
 
 	schema = spec.Definitions["withPattern"]
-	err = expandSchema(&schema, "#/definitions/withPattern", resolver)
+	err = expandSchema(&schema, []string{"#/definitions/withPattern"}, resolver)
 	assert.NoError(t, err)
 	prop := schema.PatternProperties["^x-ab"]
 	assert.Empty(t, prop.Items.Schema.Ref.String())
 	assert.Equal(t, *prop.Items.Schema, spec.Definitions["tag"])
 
 	schema = spec.Definitions["deps"]
-	err = expandSchema(&schema, "#/definitions/deps", resolver)
+	err = expandSchema(&schema, []string{"#/definitions/deps"}, resolver)
 	assert.NoError(t, err)
 	prop2 := schema.Dependencies["something"]
 	assert.Empty(t, prop2.Schema.Items.Schema.Ref.String())
 	assert.Equal(t, *prop2.Schema.Items.Schema, spec.Definitions["tag"])
 
 	schema = spec.Definitions["defined"]
-	err = expandSchema(&schema, "#/definitions/defined", resolver)
+	err = expandSchema(&schema, []string{"#/definitions/defined"}, resolver)
 	assert.NoError(t, err)
 	prop = schema.Definitions["something"]
 	assert.Empty(t, prop.Items.Schema.Ref.String())
@@ -314,7 +314,7 @@ func TestSchemaExpansion(t *testing.T) {
 	assert.NotEmpty(t, oldBrand.Ref.String())
 	assert.NotEqual(t, spec.Definitions["brand"], oldBrand)
 
-	err = expandSchema(&schema, "#/definitions/car", resolver)
+	err = expandSchema(&schema, []string{"#/definitions/car"}, resolver)
 	assert.NoError(t, err)
 
 	newBrand := schema.Properties["brand"]
@@ -324,23 +324,23 @@ func TestSchemaExpansion(t *testing.T) {
 	schema = spec.Definitions["truck"]
 	assert.NotEmpty(t, schema.Ref.String())
 
-	err = expandSchema(&schema, "#/definitions/truck", resolver)
+	err = expandSchema(&schema, []string{"#/definitions/truck"}, resolver)
 	assert.NoError(t, err)
 	assert.Empty(t, schema.Ref.String())
 	assert.Equal(t, spec.Definitions["car"], schema)
 
 	sch := new(Schema)
-	err = expandSchema(sch, "", resolver)
+	err = expandSchema(sch, []string{""}, resolver)
 	assert.NoError(t, err)
 
 	schema = spec.Definitions["batch"]
-	err = expandSchema(&schema, "#/definitions/batch", resolver)
+	err = expandSchema(&schema, []string{"#/definitions/batch"}, resolver)
 	assert.NoError(t, err)
 	assert.Empty(t, schema.Items.Schema.Ref.String())
 	assert.Equal(t, *schema.Items.Schema, spec.Definitions["brand"])
 
 	schema = spec.Definitions["batch2"]
-	err = expandSchema(&schema, "#/definitions/batch2", resolver)
+	err = expandSchema(&schema, []string{"#/definitions/batch2"}, resolver)
 	assert.NoError(t, err)
 	assert.Empty(t, schema.Items.Schemas[0].Ref.String())
 	assert.Empty(t, schema.Items.Schemas[1].Ref.String())
@@ -348,7 +348,7 @@ func TestSchemaExpansion(t *testing.T) {
 	assert.Equal(t, schema.Items.Schemas[1], spec.Definitions["tag"])
 
 	schema = spec.Definitions["allofBoth"]
-	err = expandSchema(&schema, "#/definitions/allofBoth", resolver)
+	err = expandSchema(&schema, []string{"#/definitions/allofBoth"}, resolver)
 	assert.NoError(t, err)
 	assert.Empty(t, schema.AllOf[0].Ref.String())
 	assert.Empty(t, schema.AllOf[1].Ref.String())
@@ -356,7 +356,7 @@ func TestSchemaExpansion(t *testing.T) {
 	assert.Equal(t, schema.AllOf[1], spec.Definitions["tag"])
 
 	schema = spec.Definitions["anyofBoth"]
-	err = expandSchema(&schema, "#/definitions/anyofBoth", resolver)
+	err = expandSchema(&schema, []string{"#/definitions/anyofBoth"}, resolver)
 	assert.NoError(t, err)
 	assert.Empty(t, schema.AnyOf[0].Ref.String())
 	assert.Empty(t, schema.AnyOf[1].Ref.String())
@@ -364,7 +364,7 @@ func TestSchemaExpansion(t *testing.T) {
 	assert.Equal(t, schema.AnyOf[1], spec.Definitions["tag"])
 
 	schema = spec.Definitions["oneofBoth"]
-	err = expandSchema(&schema, "#/definitions/oneofBoth", resolver)
+	err = expandSchema(&schema, []string{"#/definitions/oneofBoth"}, resolver)
 	assert.NoError(t, err)
 	assert.Empty(t, schema.OneOf[0].Ref.String())
 	assert.Empty(t, schema.OneOf[1].Ref.String())
@@ -372,39 +372,39 @@ func TestSchemaExpansion(t *testing.T) {
 	assert.Equal(t, schema.OneOf[1], spec.Definitions["tag"])
 
 	schema = spec.Definitions["notSomething"]
-	err = expandSchema(&schema, "#/definitions/notSomething", resolver)
+	err = expandSchema(&schema, []string{"#/definitions/notSomething"}, resolver)
 	assert.NoError(t, err)
 	assert.Empty(t, schema.Not.Ref.String())
 	assert.Equal(t, *schema.Not, spec.Definitions["tag"])
 
 	schema = spec.Definitions["withAdditional"]
-	err = expandSchema(&schema, "#/definitions/withAdditional", resolver)
+	err = expandSchema(&schema, []string{"#/definitions/withAdditional"}, resolver)
 	assert.NoError(t, err)
 	assert.Empty(t, schema.AdditionalProperties.Schema.Ref.String())
 	assert.Equal(t, *schema.AdditionalProperties.Schema, spec.Definitions["tag"])
 
 	schema = spec.Definitions["withAdditionalItems"]
-	err = expandSchema(&schema, "#/definitions/withAdditionalItems", resolver)
+	err = expandSchema(&schema, []string{"#/definitions/withAdditionalItems"}, resolver)
 	assert.NoError(t, err)
 	assert.Empty(t, schema.AdditionalItems.Schema.Ref.String())
 	assert.Equal(t, *schema.AdditionalItems.Schema, spec.Definitions["tag"])
 
 	schema = spec.Definitions["withPattern"]
-	err = expandSchema(&schema, "#/definitions/withPattern", resolver)
+	err = expandSchema(&schema, []string{"#/definitions/withPattern"}, resolver)
 	assert.NoError(t, err)
 	prop := schema.PatternProperties["^x-ab"]
 	assert.Empty(t, prop.Ref.String())
 	assert.Equal(t, prop, spec.Definitions["tag"])
 
 	schema = spec.Definitions["deps"]
-	err = expandSchema(&schema, "#/definitions/deps", resolver)
+	err = expandSchema(&schema, []string{"#/definitions/deps"}, resolver)
 	assert.NoError(t, err)
 	prop2 := schema.Dependencies["something"]
 	assert.Empty(t, prop2.Schema.Ref.String())
 	assert.Equal(t, *prop2.Schema, spec.Definitions["tag"])
 
 	schema = spec.Definitions["defined"]
-	err = expandSchema(&schema, "#/definitions/defined", resolver)
+	err = expandSchema(&schema, []string{"#/definitions/defined"}, resolver)
 	assert.NoError(t, err)
 	prop = schema.Definitions["something"]
 	assert.Empty(t, prop.Ref.String())


### PR DESCRIPTION
fixes [go-swagger/go-swagger #483](https://github.com/go-swagger/go-swagger/issues/483)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/go-openapi/spec/1)
<!-- Reviewable:end -->
