### PR TITLE
Add vendor extensions support for header.

### DIFF
--- a/header.go
+++ b/header.go
@@ -30,6 +30,7 @@ type HeaderProps struct {
 type Header struct {
 	CommonValidations
 	SimpleSchema
+	VendorExtensible
 	HeaderProps
 }
 
@@ -156,6 +157,9 @@ func (h *Header) UnmarshalJSON(data []byte) error {
 		return err
 	}
 	if err := json.Unmarshal(data, &h.SimpleSchema); err != nil {
+		return err
+	}
+	if err := json.Unmarshal(data, &h.VendorExtensible); err != nil {
 		return err
 	}
 	if err := json.Unmarshal(data, &h.HeaderProps); err != nil {

--- a/header_test.go
+++ b/header_test.go
@@ -29,6 +29,9 @@ func int64Ptr(f int64) *int64 {
 }
 
 var header = Header{
+	VendorExtensible: VendorExtensible{Extensions: map[string]interface{}{
+		"x-framework": "swagger-go",
+	}},
 	HeaderProps: HeaderProps{Description: "the description of this header"},
 	SimpleSchema: SimpleSchema{
 		Items: &Items{
@@ -58,6 +61,7 @@ var headerJSON = `{
   "items": {
     "$ref": "Cat"
   },
+  "x-framework": "swagger-go",
   "description": "the description of this header",
   "maximum": 100,
   "minimum": 5,


### PR DESCRIPTION
Hi, I found the header should support vendor extensions, [read here](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#header-object).

So I just have it added for you.