### PR TITLE
omit definitions from json serialization when empty

### DIFF
--- a/swagger.go
+++ b/swagger.go
@@ -77,7 +77,7 @@ type SwaggerProps struct {
 	Host                string                 `json:"host,omitempty"`
 	BasePath            string                 `json:"basePath,omitempty"` // must start with a leading "/"
 	Paths               *Paths                 `json:"paths"`              // required
-	Definitions         Definitions            `json:"definitions"`
+	Definitions         Definitions            `json:"definitions,omitempty"`
 	Parameters          map[string]Parameter   `json:"parameters,omitempty"`
 	Responses           map[string]Response    `json:"responses,omitempty"`
 	SecurityDefinitions SecurityDefinitions    `json:"securityDefinitions,omitempty"`

--- a/swagger_test.go
+++ b/swagger_test.go
@@ -319,3 +319,47 @@ func TestVendorExtensionStringSlice(t *testing.T) {
 		}
 	}
 }
+
+func TestOptionalSwaggerProps_Serialize(t *testing.T) {
+	minimalJsonSpec := []byte(`{
+	"swagger": "2.0",
+	"info": {
+		"version": "0.0.0",
+		"title": "Simple API"
+	},
+	"paths": {
+		"/": {
+			"get": {
+				"responses": {
+					"200": {
+						"description": "OK"
+					}
+				}
+			}
+		}
+	}
+}`)
+
+	var minimalSpec Swagger
+	err := json.Unmarshal(minimalJsonSpec, &minimalSpec)
+	if assert.NoError(t, err) {
+		bytes, err := json.Marshal(&minimalSpec)
+		if assert.NoError(t, err) {
+			var ms map[string]interface{}
+			if err := json.Unmarshal(bytes, &ms); assert.NoError(t, err) {
+				assert.NotContains(t, ms, "consumes")
+				assert.NotContains(t, ms, "produces")
+				assert.NotContains(t, ms, "schemes")
+				assert.NotContains(t, ms, "host")
+				assert.NotContains(t, ms, "basePath")
+				assert.NotContains(t, ms, "definitions")
+				assert.NotContains(t, ms, "parameters")
+				assert.NotContains(t, ms, "responses")
+				assert.NotContains(t, ms, "securityDefinitions")
+				assert.NotContains(t, ms, "security")
+				assert.NotContains(t, ms, "tags")
+				assert.NotContains(t, ms, "externalDocs")
+			}
+		}
+	}
+}


### PR DESCRIPTION
fixes https://github.com/go-swagger/go-swagger/issues/898