### PR TITLE
swagger: nil value should get marshaled as json null

### DIFF
--- a/swagger.go
+++ b/swagger.go
@@ -156,7 +156,7 @@ func (s SchemaOrStringArray) MarshalJSON() ([]byte, error) {
 	if s.Schema != nil {
 		return json.Marshal(s.Schema)
 	}
-	return nil, nil
+	return []byte("null"), nil
 }
 
 // UnmarshalJSON converts this schema object or array from a JSON structure


### PR DESCRIPTION
When `SchemaOrStringArray` is nil, it should get marshaled as json `null` value.