### PR TITLE
Add Example field to SimpleSchema

### DIFF
--- a/items.go
+++ b/items.go
@@ -28,6 +28,7 @@ type SimpleSchema struct {
 	Items            *Items      `json:"items,omitempty"`
 	CollectionFormat string      `json:"collectionFormat,omitempty"`
 	Default          interface{} `json:"default,omitempty"`
+	Example          interface{} `json:"example,omitempty"`
 }
 
 func (s *SimpleSchema) TypeName() string {


### PR DESCRIPTION
Add an `Example` field to `SimpleSchema` to support [example values](https://swagger.io/docs/specification/adding-examples/).

From my limited understanding of OpenAPI and a quick perusal of the codebase, `SimpleSchema` seemed like the right place to put the example field; if there's a better place please let me know.