### PR TITLE
Don't drop empty arrays of operations security definitions

### DIFF
--- a/operation.go
+++ b/operation.go
@@ -31,7 +31,7 @@ type OperationProps struct {
 	ExternalDocs *ExternalDocumentation `json:"externalDocs,omitempty"`
 	ID           string                 `json:"operationId,omitempty"`
 	Deprecated   bool                   `json:"deprecated,omitempty"`
-	Security     []map[string][]string  `json:"security,omitempty"`
+	Security     []map[string][]string  `json:"security"`
 	Parameters   []Parameter            `json:"parameters,omitempty"`
 	Responses    *Responses             `json:"responses,omitempty"`
 }


### PR DESCRIPTION
Empty arrays habe meaning in this place and a are different from the field not being set.
Thy can be used to override global `security` settings.
Fixes https://github.com/go-swagger/go-swagger/issues/1281