### PR TITLE
Avoid null value when serializing operations

### DIFF
--- a/operation.go
+++ b/operation.go
@@ -31,9 +31,34 @@ type OperationProps struct {
 	ExternalDocs *ExternalDocumentation `json:"externalDocs,omitempty"`
 	ID           string                 `json:"operationId,omitempty"`
 	Deprecated   bool                   `json:"deprecated,omitempty"`
-	Security     []map[string][]string  `json:"security"`
+	Security     []map[string][]string  `json:"security,omitempty"` //Special case, see MarshalJSON function
 	Parameters   []Parameter            `json:"parameters,omitempty"`
 	Responses    *Responses             `json:"responses,omitempty"`
+}
+
+// MarshalJSON takes care of serializing operation properties to JSON
+//
+// We use a custom marhaller here to handle a special cases related
+// the Security field. We need to preserve zero length slice
+// while omiting the field when the value is nil/unset.
+func (op OperationProps) MarshalJSON() ([]byte, error) {
+	type Alias OperationProps
+	if op.Security == nil {
+		return json.Marshal(&struct {
+			Security []map[string][]string `json:"security,omitempty"`
+			*Alias
+		}{
+			Security: op.Security,
+			Alias:    (*Alias)(&op),
+		})
+	}
+	return json.Marshal(&struct {
+		Security []map[string][]string `json:"security"`
+		*Alias
+	}{
+		Security: op.Security,
+		Alias:    (*Alias)(&op),
+	})
 }
 
 // Operation describes a single API operation on a path.

--- a/operation_test.go
+++ b/operation_test.go
@@ -83,3 +83,25 @@ func TestIntegrationOperation(t *testing.T) {
 
 	assertParsesJSON(t, operationJSON, operation)
 }
+
+func TestSecurityProperty(t *testing.T) {
+	//Ensure we omit security key when unset
+	securityNotSet := OperationProps{}
+	jsonResult, err := json.Marshal(securityNotSet)
+	if assert.NoError(t, err) {
+		assert.NotContains(t, string(jsonResult), "security", "security key should be omitted when unset")
+	}
+
+	//Ensure we preseve the security key when it contains an empty (zero length) slice
+	securityContainsEmptyArray := OperationProps{
+		Security: []map[string][]string{},
+	}
+	jsonResult, err = json.Marshal(securityContainsEmptyArray)
+	if assert.NoError(t, err) {
+		var props OperationProps
+		if assert.NoError(t, json.Unmarshal(jsonResult, &props)) {
+			assert.Equal(t, securityContainsEmptyArray, props)
+		}
+	}
+
+}


### PR DESCRIPTION
This fixes a regression introduced by #39.
Turns out `security: null` breaks the validator as it expected either no field at all or an array.

OperatioProperties now have a custom marshaller that ensures that:
1. empty slices are preserved as empty arrays in JSON
2. if Security is unset/nil the key is omitted in JSON