### PR TITLE
Fix expandSchema when basePath is empty

### DIFF
--- a/expander.go
+++ b/expander.go
@@ -651,14 +651,16 @@ func expandSchema(target Schema, parentRefs []string, resolver *schemaLoader, ba
 	/* Ref also changes the resolution scope of children expandSchema */
 	if target.Ref.String() != "" {
 		/* Here the resolution scope is changed because a $ref was encountered */
-		newRef := normalizeFileRef(&target.Ref, basePath)
-		newBasePath := newRef.RemoteURI()
+		normalizedRef := normalizeFileRef(&target.Ref, basePath)
+		normalizedBasePath := normalizedRef.RemoteURI()
+
 		/* this means there is a circle in the recursion tree */
 		/* return the Ref */
-		if swag.ContainsStringsCI(parentRefs, newRef.String()) {
-			target.Ref = *newRef
+		if basePath != "" && swag.ContainsStringsCI(parentRefs, normalizedRef.String()) {
+			target.Ref = *normalizedRef
 			return &target, nil
 		}
+
 		debugLog("\nbasePath: %s", basePath)
 		b, _ := json.Marshal(target)
 		debugLog("calling Resolve with target: %s", string(b))
@@ -667,8 +669,8 @@ func expandSchema(target Schema, parentRefs []string, resolver *schemaLoader, ba
 		}
 
 		if t != nil {
-			parentRefs = append(parentRefs, newRef.String())
-			return expandSchema(*t, parentRefs, resolver, newBasePath)
+			parentRefs = append(parentRefs, normalizedRef.String())
+			return expandSchema(*t, parentRefs, resolver, normalizedBasePath)
 		}
 	}
 


### PR DESCRIPTION
Note that **I am not sure** that this is the correct way to fix the issue (and if this fix does not break anything) because I am not familiar with #38 changes.

But at least my code that I wrote before #38 finally works after this fix.

---

Fixes #45

Signed-off-by: Igor Zibarev <zibarev.i@gmail.com>