### PR TITLE
47-Delete temporary files before program termination

### DIFF
--- a/expander.go
+++ b/expander.go
@@ -535,6 +535,7 @@ func ExpandSchema(schema *Schema, root interface{}, cache ResolutionCache) error
 	if err != nil {
 		return err
 	}
+  defer os.Remove(file.Name())
 
 	switch r := root.(type) {
 	case *Schema:


### PR DESCRIPTION
The ExpandSchema() method calls ioutil.TempFile(), which creates a temporary file, and the file is not deleted before program termination. As specified in the golang documentation, it is the caller's responsibility to delete temporary files created by ioutil.TempFile()