### PR TITLE
- Don't write root schema to disk.

### DIFF
--- a/expander.go
+++ b/expander.go
@@ -16,9 +16,7 @@ package spec
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net/url"
 	"os"
@@ -379,29 +377,26 @@ func (r *schemaLoader) resolveRef(ref *Ref, target interface{}, basePath string)
 		return nil
 	}
 
-	// if no basePath is provided, we attempt to resolve the reference against root
-	if basePath == "" {
-		var b []byte
-		switch rr := r.root.(type) {
-		case *Schema:
-			b, _ = rr.MarshalJSON()
-		case *Swagger:
-			b, _ = rr.MarshalJSON()
+	var data interface{}
+	var err error
+	// Resolve against the root if it isn't nil, and if ref is pointing at the root, or has a fragment only which means
+	// it is pointing somewhere in the root.
+	root := r.root
+	if (ref.IsRoot() || ref.HasFragmentOnly) && root == nil && basePath != "" {
+		if baseRef, err := NewRef(basePath); err == nil {
+			root, _, _, _ = r.load(baseRef.GetURL())
 		}
-		f, err := ioutil.TempFile(os.TempDir(), "tmproot")
+	}
+	if (ref.IsRoot() || ref.HasFragmentOnly) && root != nil {
+		data = root
+	} else {
+		baseRef := normalizeFileRef(ref, basePath)
+		debugLog("current ref is: %s", ref.String())
+		debugLog("current ref normalized file: %s", baseRef.String())
+		data, _, _, err = r.load(baseRef.GetURL())
 		if err != nil {
 			return err
 		}
-		f.Write(b)
-		f.Close()
-		basePath = f.Name()
-	}
-
-	baseRef := normalizeFileRef(ref, basePath)
-	debugLog("current ref normalized file: %s", baseRef.String())
-	data, _, _, err := r.load(baseRef.GetURL())
-	if err != nil {
-		return err
 	}
 
 	var res interface{}
@@ -471,11 +466,10 @@ func ExpandSpec(spec *Swagger, options *ExpandOptions) error {
 	}
 
 	if options == nil || !options.SkipSchemas {
-		rt := fmt.Sprintf("%s#/definitions/", specBasePath)
 		for key, definition := range spec.Definitions {
 			var def *Schema
 			var err error
-			if def, err = expandSchema(definition, []string{rt + key}, resolver, specBasePath); shouldStopOnError(err, resolver.options) {
+			if def, err = expandSchema(definition, []string{fmt.Sprintf("#/defintions/%s", key)}, resolver, specBasePath); shouldStopOnError(err, resolver.options) {
 				return err
 			}
 			if def != nil {
@@ -526,29 +520,19 @@ func shouldStopOnError(err error, opts *ExpandOptions) bool {
 // go-openapi/validate uses this function
 // notice that it is impossible to reference a json scema in a different file other than root
 func ExpandSchema(schema *Schema, root interface{}, cache ResolutionCache) error {
-	// if root is passed as nil, assume root is the same as schema
-	if root == nil {
-		root = schema
+	// Only save the root to a tmp file if it isn't nil.
+	var base string
+	if root != nil {
+		base, _ = absPath("root")
+		if cache == nil {
+			cache = resCache
+		}
+		cache.Set(base, root)
+		base = "root"
 	}
-
-	file, err := ioutil.TempFile(os.TempDir(), "root")
-	if err != nil {
-		return err
-	}
-	defer os.Remove(file.Name())
-
-	switch r := root.(type) {
-	case *Schema:
-		b, _ := r.MarshalJSON()
-		file.Write(b)
-	case *Swagger:
-		b, _ := r.MarshalJSON()
-		file.Write(b)
-	}
-	file.Close()
 
 	opts := &ExpandOptions{
-		RelativeBase:    file.Name(),
+		RelativeBase:    base,
 		SkipSchemas:     false,
 		ContinueOnError: false,
 	}
@@ -561,14 +545,10 @@ func ExpandSchemaWithBasePath(schema *Schema, cache ResolutionCache, opts *Expan
 		return nil
 	}
 
-	if opts == nil {
-		return errors.New("cannot expand schema without a base path")
+	var basePath string
+	if opts.RelativeBase != "" {
+		basePath, _ = absPath(opts.RelativeBase)
 	}
-	if opts.RelativeBase == "" {
-		return errors.New("cannot expand schema with empty base path")
-	}
-
-	basePath, _ := absPath(opts.RelativeBase)
 
 	resolver, err := defaultSchemaLoader(nil, opts, cache)
 	if err != nil {

--- a/fixtures/expansion/missingRef.json
+++ b/fixtures/expansion/missingRef.json
@@ -14,12 +14,12 @@
               "schema": {
                 "type": "array",
                 "items": {
-                  "$ref": "#/input/definitions/todo-full"
+                  "$ref": "#/definitions/todo-full"
                 }
               }
             },
             "404": {
-              "$ref": "#/input/responses/404"
+              "$ref": "#/responses/404"
             }
           }
         }
@@ -40,7 +40,7 @@
       "todo-full": {
         "allOf": [
           {
-            "$ref": "#/input/definitions/todo-partial"
+            "$ref": "#/definitions/todo-partial"
           },
           {
             "type": "object",


### PR DESCRIPTION
- When ref has a fragment only or is pointing to root and root is nil then resolve against the root
- can expand schema without a base path
- speed up spec expansion