### PR TITLE
normalize cache key for root in ExpandSchema

### DIFF
--- a/expander.go
+++ b/expander.go
@@ -318,6 +318,17 @@ func debugLog(msg string, args ...interface{}) {
 	}
 }
 
+// normalize absolute path for cache.
+// on Windows, drive letters should be converted to lower as scheme in net/url.URL
+func normalizeAbsPath(path string) string {
+	u, err := url.Parse(path)
+	if err != nil {
+		debugLog("normalize absolute path failed: %s", err)
+		return path
+	}
+	return u.String()
+}
+
 // base or refPath could be a file path or a URL
 // given a base absolute path and a ref path, return the absolute path of refPath
 // 1) if refPath is absolute, return it
@@ -530,7 +541,7 @@ func ExpandSchema(schema *Schema, root interface{}, cache ResolutionCache) error
 		if cache == nil {
 			cache = resCache
 		}
-		cache.Set(base, root)
+		cache.Set(normalizeAbsPath(base), root)
 		base = "root"
 	}
 


### PR DESCRIPTION
the cache is queried by normalized key.
but in ExpandSchema(), root was stored with un-normalized key.

this causes trouble on Windows which have drive letter as upper case in
absolute path.  when normalize this absolute path, drive letter is converted
to lower case.  and it causes cache miss and ExpandSchema() failure.