### PR TITLE
improve performance of schema deserialize

### DIFF
--- a/ref.go
+++ b/ref.go
@@ -145,7 +145,10 @@ func (r *Ref) UnmarshalJSON(d []byte) error {
 	if err := json.Unmarshal(d, &v); err != nil {
 		return err
 	}
+	return r.fromMap(v)
+}
 
+func (r *Ref) fromMap(v map[string]interface{}) error {
 	if v == nil {
 		return nil
 	}

--- a/schema.go
+++ b/schema.go
@@ -135,6 +135,10 @@ func (r *SchemaURL) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &v); err != nil {
 		return err
 	}
+	return r.fromMap(v)
+}
+
+func (r *SchemaURL) fromMap(v map[string]interface{}) error {
 	if v == nil {
 		return nil
 	}
@@ -582,24 +586,26 @@ func (s Schema) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON marshal this from JSON
 func (s *Schema) UnmarshalJSON(data []byte) error {
-	var sch Schema
-	if err := json.Unmarshal(data, &sch.SchemaProps); err != nil {
+	props := struct {
+		SchemaProps
+		SwaggerSchemaProps
+	}{}
+	if err := json.Unmarshal(data, &props); err != nil {
 		return err
 	}
-	if err := json.Unmarshal(data, &sch.Ref); err != nil {
-		return err
-	}
-	if err := json.Unmarshal(data, &sch.Schema); err != nil {
-		return err
-	}
-	if err := json.Unmarshal(data, &sch.SwaggerSchemaProps); err != nil {
-		return err
+
+	sch := Schema{
+		SchemaProps:        props.SchemaProps,
+		SwaggerSchemaProps: props.SwaggerSchemaProps,
 	}
 
 	var d map[string]interface{}
 	if err := json.Unmarshal(data, &d); err != nil {
 		return err
 	}
+
+	sch.Ref.fromMap(d)
+	sch.Schema.fromMap(d)
 
 	delete(d, "$ref")
 	delete(d, "$schema")

--- a/schema_test.go
+++ b/schema_test.go
@@ -203,3 +203,10 @@ func TestSchema(t *testing.T) {
 	}
 
 }
+
+func BenchmarkSchemaUnmarshal(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		sch := &Schema{}
+		sch.UnmarshalJSON([]byte(schemaJSON))
+	}
+}


### PR DESCRIPTION
and add some benchmarks. This is a bottleneck for the kubernetes unit tests.
The fix works by caching the deserialization of the full schema into a
map. We were doing this three times. Now we only do it once.

Before:
```    
    BenchmarkSchemaUnmarshal-12
            50000            321498 ns/op           86325 B/op       1400 allocs/op
```

After:

```    
    BenchmarkSchemaUnmarshal-12
           100000            131877 ns/op           46183 B/op        535 allocs/op
```

@mbohlool 