### PR TITLE
resolver cache setting fix for Windows, normalize and tests

### DIFF
--- a/expander.go
+++ b/expander.go
@@ -336,12 +336,13 @@ func normalizeAbsPath(path string) string {
 // base could be a directory or a full file path
 func normalizePaths(refPath, base string) string {
 	refURL, _ := url.Parse(refPath)
-	if path.IsAbs(refURL.Path) {
+	if path.IsAbs(refURL.Path) || filepath.IsAbs(refPath) {
 		// refPath is actually absolute
 		if refURL.Host != "" {
 			return refPath
 		}
-		return filepath.FromSlash(refPath)
+		parts := strings.Split(refPath, "#")
+		return fmt.Sprintf("%s#%s", filepath.FromSlash(parts[0]), parts[1])
 	}
 
 	// relative refPath

--- a/expander.go
+++ b/expander.go
@@ -23,6 +23,7 @@ import (
 	"path"
 	"path/filepath"
 	"reflect"
+	"regexp"
 	"strings"
 	"sync"
 
@@ -463,7 +464,14 @@ func absPath(fname string) (string, error) {
 		return fname, nil
 	}
 	wd, err := os.Getwd()
-	return filepath.Join(wd, fname), err
+	fullPath := filepath.Join(wd, fname)
+
+	submatches := regexp.MustCompile(`^[\w]+:`).FindStringSubmatch(fullPath)
+	if len(submatches) > 0 {
+		fullPath = strings.ToLower(submatches[0])+fullPath[len(submatches[0]):]
+	}
+
+	return fullPath, err
 }
 
 // ExpandSpec expands the references in a swagger spec

--- a/expander.go
+++ b/expander.go
@@ -342,7 +342,11 @@ func normalizePaths(refPath, base string) string {
 			return refPath
 		}
 		parts := strings.Split(refPath, "#")
-		return fmt.Sprintf("%s#%s", filepath.FromSlash(parts[0]), parts[1])
+		result := filepath.FromSlash(parts[0])
+		if len(parts) == 2 {
+			result += "#" + parts[1]
+		}
+		return result
 	}
 
 	// relative refPath

--- a/expander_test.go
+++ b/expander_test.go
@@ -61,6 +61,12 @@ func TestNormalizePaths(t *testing.T) {
 		if runtime.GOOS == "windows" {
 			testCases = append(testCases, testNormalizePathsTestCases{
 				{
+					// file basePath, absolute refPath, no fragment
+					refPath:   `C:\another\base\path.json`,
+					base:      `C:\base\path.json`,
+					expOutput: `C:\another\base\path.json`,
+				},
+				{
 					// file basePath, absolute refPath
 					refPath:   `C:\another\base\path.json#/definitions/Pet`,
 					base:      `C:\base\path.json`,
@@ -77,6 +83,12 @@ func TestNormalizePaths(t *testing.T) {
 		}
 		// linux case
 		testCases = append(testCases, testNormalizePathsTestCases{
+			{
+				// file basePath, absolute refPath, no fragment
+				refPath:   "/another/base/path.json",
+				base:      "/base/path.json",
+				expOutput: "/another/base/path.json",
+			},
 			{
 				// file basePath, absolute refPath
 				refPath:   "/another/base/path.json#/definitions/Pet",

--- a/expander_test.go
+++ b/expander_test.go
@@ -20,6 +20,7 @@ import (
 	"log"
 	"net/http"
 	"net/http/httptest"
+	"runtime"
 	"testing"
 
 	"github.com/go-openapi/jsonpointer"
@@ -37,36 +38,60 @@ func jsonDoc(path string) (json.RawMessage, error) {
 
 // tests that paths are normalized correctly
 func TestNormalizePaths(t *testing.T) {
-	testCases := []struct {
+	type testNormalizePathsTestCases []struct {
 		refPath   string
 		base      string
 		expOutput string
-	}{
-		{
-			// file basePath, absolute refPath
-			refPath:   "/another/base/path.json#/definitions/Pet",
-			base:      "/base/path.json",
-			expOutput: "/another/base/path.json#/definitions/Pet",
-		},
-		{
-			// file basePath, relative refPath
-			refPath:   "another/base/path.json#/definitions/Pet",
-			base:      "/base/path.json",
-			expOutput: "/base/another/base/path.json#/definitions/Pet",
-		},
-		{
-			// http basePath, absolute refPath
-			refPath:   "http://www.anotherexample.com/another/base/path/swagger.json#/definitions/Pet",
-			base:      "http://www.example.com/base/path/swagger.json",
-			expOutput: "http://www.anotherexample.com/another/base/path/swagger.json#/definitions/Pet",
-		},
-		{
-			// http basePath, relative refPath
-			refPath:   "another/base/path/swagger.json#/definitions/Pet",
-			base:      "http://www.example.com/base/path/swagger.json",
-			expOutput: "http://www.example.com/base/path/another/base/path/swagger.json#/definitions/Pet",
-		},
 	}
+	testCases := func() testNormalizePathsTestCases {
+		testCases := testNormalizePathsTestCases{
+			{
+				// http basePath, absolute refPath
+				refPath:   "http://www.anotherexample.com/another/base/path/swagger.json#/definitions/Pet",
+				base:      "http://www.example.com/base/path/swagger.json",
+				expOutput: "http://www.anotherexample.com/another/base/path/swagger.json#/definitions/Pet",
+			},
+			{
+				// http basePath, relative refPath
+				refPath:   "another/base/path/swagger.json#/definitions/Pet",
+				base:      "http://www.example.com/base/path/swagger.json",
+				expOutput: "http://www.example.com/base/path/another/base/path/swagger.json#/definitions/Pet",
+			},
+		}
+		if runtime.GOOS == "windows" {
+			testCases = append(testCases, testNormalizePathsTestCases{
+				{
+					// file basePath, absolute refPath
+					refPath:   `C:\another\base\path.json#/definitions/Pet`,
+					base:      `C:\base\path.json`,
+					expOutput: `C:\another\base\path.json#/definitions/Pet`,
+				},
+				{
+					// file basePath, relative refPath
+					refPath:   `another\base\path.json#/definitions/Pet`,
+					base:      `C:\base\path.json`,
+					expOutput: `C:\base\another\base\path.json#/definitions/Pet`,
+				},
+			}...)
+			return testCases
+		}
+		// linux case
+		testCases = append(testCases, testNormalizePathsTestCases{
+			{
+				// file basePath, absolute refPath
+				refPath:   "/another/base/path.json#/definitions/Pet",
+				base:      "/base/path.json",
+				expOutput: "/another/base/path.json#/definitions/Pet",
+			},
+			{
+				// file basePath, relative refPath
+				refPath:   "another/base/path.json#/definitions/Pet",
+				base:      "/base/path.json",
+				expOutput: "/base/another/base/path.json#/definitions/Pet",
+			},
+		}...)
+		return testCases
+	}()
 
 	for _, tcase := range testCases {
 		out := normalizePaths(tcase.refPath, tcase.base)


### PR DESCRIPTION
This is a fix for the issues: https://github.com/go-openapi/spec/issues/66, https://github.com/go-openapi/spec/issues/63, https://github.com/go-openapi/spec/issues/64

Probably this doesn't fix: https://github.com/go-openapi/spec/issues/65