### PR TITLE
Relocate relative $ref in response and param schema

### DIFF
--- a/expander.go
+++ b/expander.go
@@ -968,6 +968,14 @@ func expandResponse(response *Response, resolver *schemaLoader, basePath string)
 			return err
 		}
 	}
+	if response.Schema != nil && response.Schema.Ref.String() != "" {
+		// schema expanded to a $ref in another root
+		var ern error
+		response.Schema.Ref, ern = NewRef(normalizePaths(response.Schema.Ref.String(), response.Ref.RemoteURI()))
+		if ern != nil {
+			return ern
+		}
+	}
 	response.Ref = Ref{}
 
 	parentRefs = parentRefs[0:]
@@ -1035,6 +1043,15 @@ func expandParameter(parameter *Parameter, resolver *schemaLoader, basePath stri
 		resolver, err = transitiveResolver(basePath, parameter.Ref, resolver)
 		if shouldStopOnError(err, resolver.options) {
 			return err
+		}
+	}
+
+	if parameter.Schema != nil && parameter.Schema.Ref.String() != "" {
+		// schema expanded to a $ref in another root
+		var ern error
+		parameter.Schema.Ref, ern = NewRef(normalizePaths(parameter.Schema.Ref.String(), parameter.Ref.RemoteURI()))
+		if ern != nil {
+			return ern
 		}
 	}
 	parameter.Ref = Ref{}

--- a/fixtures/bugs/1429/remote/remote.yaml
+++ b/fixtures/bugs/1429/remote/remote.yaml
@@ -1,0 +1,8 @@
+aRemotePlace:
+  type: object
+  properties:
+    remoteProp:
+      type: integer
+
+moreRemoteThanYouCanThink:
+  $ref: './remote/remote.yaml#/farFarAway'

--- a/fixtures/bugs/1429/remote/remote/remote.yaml
+++ b/fixtures/bugs/1429/remote/remote/remote.yaml
@@ -1,0 +1,5 @@
+farFarAway:
+  type: object
+  properties:
+    farFarAwayProp:
+      type: integer

--- a/fixtures/bugs/1429/responses.yaml
+++ b/fixtures/bugs/1429/responses.yaml
@@ -1,0 +1,104 @@
+swagger: '2.0'
+info:
+  title: Responses
+  version: 0.1.0
+
+definitions:
+  Error:
+    type: object
+    description: |
+      Contains all the properties any error response from the API will contain.
+      Some properties are optional so might be empty most of the time
+    required:
+      - code
+      - message
+    properties:
+      code:
+        description: the error code, this is not necessarily the http status code
+        type: integer
+        format: int32
+      message:
+        description: a human readable version of the error
+        type: string
+      helpUrl:
+        description: an optional url for getting more help about this error
+        type: string
+        format: uri
+
+  myArray:
+    type: array
+    items:
+      $ref: '#/definitions/myItems'
+
+  myItems:
+    type: object
+    properties:
+      propItems1:
+        type: integer
+      propItems2:
+        $ref: 'remote/remote.yaml#/aRemotePlace'
+
+otherPlace:
+  Error:
+    type: object
+    properties:
+      message:
+        type: string
+
+parameters:
+  BadRequest:
+    name: badRequest
+    in: body
+    schema:
+      $ref: '#/definitions/Error'
+  GoodRequest:
+    name: goodRequest
+    in: body
+    schema:
+      $ref: '#/otherPlace/Error'
+  PlainRequest:
+    name: plainRequest
+    in: body
+    schema:
+      type: integer
+  StrangeRequest:
+    name: stangeRequest
+    in: body
+    schema:
+      $ref: 'responses.yaml#/otherPlace/Error'
+  RemoteRequest:
+    name: remoteRequest
+    in: body
+    schema:
+      $ref: './remote/remote.yaml#/moreRemoteThanYouCanThink'
+
+responses:
+  BadRequest:
+    description: Bad request
+    schema:
+      $ref: '#/definitions/Error'
+  GoodRequest:
+    description: good request
+    schema:
+      $ref: '#/otherPlace/Error'
+  PlainRequest:
+    description: plain request
+    schema:
+      type: integer
+  StrangeRequest:
+    description: strange request
+    schema:
+      $ref: 'responses.yaml#/otherPlace/Error'
+  RemoteRequest:
+    description: remote request
+    schema:
+      $ref: './remote/remote.yaml#/moreRemoteThanYouCanThink'
+
+paths:
+  /:
+    get:
+      summary: GET
+      operationId: getAll
+      responses:
+        200:
+          description: Ok

--- a/fixtures/bugs/1429/swagger.yaml
+++ b/fixtures/bugs/1429/swagger.yaml
@@ -1,0 +1,39 @@
+swagger: '2.0'
+info:
+  title: Object
+  version: 0.1.0
+
+paths:
+  /:
+    get:
+      summary: GET
+      operationId: getAll
+      parameters:
+        - $ref: 'responses.yaml#/parameters/BadRequest'
+        - $ref: 'responses.yaml#/parameters/GoodRequest'
+        - $ref: 'responses.yaml#/parameters/PlainRequest'
+        - $ref: 'responses.yaml#/parameters/StrangeRequest'
+        - $ref: 'responses.yaml#/parameters/RemoteRequest'
+        - name: nestedBody
+          in: body
+          schema:
+            $ref: '#/definitions/nestedRefDefinition'
+      responses:
+        200:
+          description: Ok
+        400:
+          $ref: 'responses.yaml#/responses/BadRequest'
+        403:
+          $ref: 'responses.yaml#/responses/GoodRequest'
+        404:
+          $ref: 'responses.yaml#/responses/PlainRequest'
+        304:
+          $ref: 'responses.yaml#/responses/StrangeRequest'
+        204:
+          $ref: 'responses.yaml#/responses/RemoteRequest'
+
+definitions:
+  badDefinition:
+    $ref: 'responses.yaml#/definitions/Error'
+  nestedRefDefinition:
+    $ref: 'responses.yaml#/definitions/myArray'

--- a/spec_test.go
+++ b/spec_test.go
@@ -1,0 +1,145 @@
+// Copyright 2015 go-swagger maintainers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spec_test
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/go-openapi/spec"
+	"github.com/go-openapi/swag"
+	"github.com/stretchr/testify/assert"
+)
+
+// mimics what the go-openapi/load does
+var yamlLoader func(string) (json.RawMessage, error) = swag.YAMLDoc
+
+func loadOrFail(t *testing.T, path string) *spec.Swagger {
+	raw, erl := yamlLoader(path)
+	if erl != nil {
+		t.Logf("can't load fixture %s: %v", path, erl)
+		t.FailNow()
+		return nil
+	}
+	swspec := new(spec.Swagger)
+	if err := json.Unmarshal(raw, swspec); err != nil {
+		t.FailNow()
+		return nil
+	}
+	return swspec
+}
+
+// Test unitary fixture for dev and bug fixing
+func Test_Issue1429(t *testing.T) {
+	prevPathLoader := spec.PathLoader
+	defer func() {
+		spec.PathLoader = prevPathLoader
+	}()
+	spec.PathLoader = yamlLoader
+	path := filepath.Join("fixtures", "bugs", "1429", "swagger.yaml")
+
+	// load and full expand
+	sp := loadOrFail(t, path)
+	err := spec.ExpandSpec(sp, &spec.ExpandOptions{RelativeBase: path, SkipSchemas: false})
+	if !assert.NoError(t, err) {
+		t.FailNow()
+		return
+	}
+
+	// assert well expanded
+	if !assert.Truef(t, (sp.Paths != nil && sp.Paths.Paths != nil), "expected paths to be available in fixture") {
+		t.FailNow()
+		return
+	}
+	for _, pi := range sp.Paths.Paths {
+		for _, param := range pi.Get.Parameters {
+			if assert.NotNilf(t, param.Schema, "expected param schema not to be nil") {
+				// all param fixtures are body param with schema
+				// all $ref expanded
+				assert.Equal(t, "", param.Schema.Ref.String())
+			}
+		}
+		for code, response := range pi.Get.Responses.StatusCodeResponses {
+			// all response fixtures are with StatusCodeResponses, but 200
+			if code == 200 {
+				assert.Nilf(t, response.Schema, "expected response schema to be nil")
+				continue
+			}
+			if assert.NotNilf(t, response.Schema, "expected response schema not to be nil") {
+				assert.Equal(t, "", response.Schema.Ref.String())
+			}
+		}
+	}
+	for _, def := range sp.Definitions {
+		assert.Equal(t, "", def.Ref.String())
+	}
+
+	// reload and SkipSchemas: true
+	sp = loadOrFail(t, path)
+	err = spec.ExpandSpec(sp, &spec.ExpandOptions{RelativeBase: path, SkipSchemas: true})
+	if !assert.NoError(t, err) {
+		t.FailNow()
+		return
+	}
+
+	// assert well resolved
+	if !assert.Truef(t, (sp.Paths != nil && sp.Paths.Paths != nil), "expected paths to be available in fixture") {
+		t.FailNow()
+		return
+	}
+	for _, pi := range sp.Paths.Paths {
+		for _, param := range pi.Get.Parameters {
+			if assert.NotNilf(t, param.Schema, "expected param schema not to be nil") {
+				// all param fixtures are body param with schema
+				if param.Name == "plainRequest" {
+					// this one is expanded
+					assert.Equal(t, "", param.Schema.Ref.String())
+					continue
+				}
+				if param.Name == "nestedBody" {
+					// this one is local
+					assert.True(t, strings.HasPrefix(param.Schema.Ref.String(), "#/definitions/"))
+					continue
+				}
+				if param.Name == "remoteRequest" {
+					assert.Contains(t, param.Schema.Ref.String(), "remote/remote.yaml#/")
+					continue
+				}
+				assert.Contains(t, param.Schema.Ref.String(), "responses.yaml#/")
+			}
+		}
+		for code, response := range pi.Get.Responses.StatusCodeResponses {
+			// all response fixtures are with StatusCodeResponses, but 200
+			if code == 200 {
+				assert.Nilf(t, response.Schema, "expected response schema to be nil")
+				continue
+			}
+			if code == 204 {
+				assert.Contains(t, response.Schema.Ref.String(), "remote/remote.yaml#/")
+				continue
+			}
+			if code == 404 {
+				assert.Equal(t, "", response.Schema.Ref.String())
+				continue
+			}
+			assert.Containsf(t, response.Schema.Ref.String(), "responses.yaml#/", "expected remote ref at resp. %d", code)
+		}
+	}
+	for _, def := range sp.Definitions {
+		assert.Contains(t, def.Ref.String(), "responses.yaml#/")
+	}
+}


### PR DESCRIPTION
- Contributes to go-swagger/go-swagger#1429
- Fixes #77 

This fixes the case when SkipSchema:true, there are remote $ref in
in schema for params and responses declared themselves with $ref (!)