### PR TITLE
Fix go-swagger/go-swagger#1816

### DIFF
--- a/ref.go
+++ b/ref.go
@@ -15,6 +15,8 @@
 package spec
 
 import (
+	"bytes"
+	"encoding/gob"
 	"encoding/json"
 	"net/http"
 	"os"
@@ -146,6 +148,28 @@ func (r *Ref) UnmarshalJSON(d []byte) error {
 		return err
 	}
 	return r.fromMap(v)
+}
+
+// GobEncode provides a safe gob encoder for Ref
+func (r Ref) GobEncode() ([]byte, error) {
+	var b bytes.Buffer
+	raw, err := r.MarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	err = gob.NewEncoder(&b).Encode(raw)
+	return b.Bytes(), err
+}
+
+// GobDecode provides a safe gob decoder for Ref
+func (r *Ref) GobDecode(b []byte) error {
+	var raw []byte
+	buf := bytes.NewBuffer(b)
+	err := gob.NewDecoder(buf).Decode(&raw)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(raw, r)
 }
 
 func (r *Ref) fromMap(v map[string]interface{}) error {

--- a/ref_test.go
+++ b/ref_test.go
@@ -1,0 +1,47 @@
+// Copyright 2015 go-swagger maintainers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spec
+
+import (
+	"bytes"
+	"encoding/gob"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// pin pointing go-swagger/go-swagger#1816 issue with cloning ref's
+func TestCloneRef(t *testing.T) {
+	var b bytes.Buffer
+	src := MustCreateRef("#/definitions/test")
+	err := gob.NewEncoder(&b).Encode(&src)
+	if !assert.NoError(t, err) {
+		t.FailNow()
+	}
+
+	var dst Ref
+	err = gob.NewDecoder(&b).Decode(&dst)
+	if !assert.NoError(t, err) {
+		t.FailNow()
+	}
+
+	jazon, err := json.Marshal(dst)
+	if !assert.NoError(t, err) {
+		t.FailNow()
+	}
+
+	assert.Equal(t, `{"$ref":"#/definitions/test"}`, string(jazon))
+}


### PR DESCRIPTION
Fix regression on unmarshalling Ref types by using gob encode/decode

* Contributes go-swagger/go-swagger#1816

Signed-off-by: Frederic BIDON <fredbi@yahoo.com>