### PR TITLE
Add nullable

### DIFF
--- a/items.go
+++ b/items.go
@@ -29,6 +29,7 @@ const (
 // SimpleSchema describe swagger simple schemas for parameters and headers
 type SimpleSchema struct {
 	Type             string      `json:"type,omitempty"`
+	Nullable         bool        `json:"nullable,omitempty"`
 	Format           string      `json:"format,omitempty"`
 	Items            *Items      `json:"items,omitempty"`
 	CollectionFormat string      `json:"collectionFormat,omitempty"`
@@ -88,6 +89,12 @@ func NewItems() *Items {
 func (i *Items) Typed(tpe, format string) *Items {
 	i.Type = tpe
 	i.Format = format
+	return i
+}
+
+// AsNullable flags this schema as nullable.
+func (i *Items) AsNullable() *Items {
+	i.Nullable = true
 	return i
 }
 

--- a/schema.go
+++ b/schema.go
@@ -163,6 +163,7 @@ type SchemaProps struct {
 	Schema               SchemaURL         `json:"-"`
 	Description          string            `json:"description,omitempty"`
 	Type                 StringOrArray     `json:"type,omitempty"`
+	Nullable             bool              `json:"nullable,omitempty"`
 	Format               string            `json:"format,omitempty"`
 	Title                string            `json:"title,omitempty"`
 	Default              interface{}       `json:"default,omitempty"`
@@ -299,6 +300,12 @@ func (s *Schema) AddType(tpe, format string) *Schema {
 	if format != "" {
 		s.Format = format
 	}
+	return s
+}
+
+// AsNullable flags this schema as nullable.
+func (s *Schema) AsNullable() *Schema {
+	s.Nullable = true
 	return s
 }
 


### PR DESCRIPTION
Towards v3 support, we have to add nullable, as an alternative to the JSON-Schema inspired `null` type.

Note, that both are not 100% the same as `type:"", nullable:true` is a valid construct which cannot be faithfully represented with the `null` type only.