### PR TITLE
Reduce memory usage at package init time

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -45,14 +45,17 @@ func (s *simpleCache) Set(uri string, data interface{}) {
 	s.lock.Unlock()
 }
 
-var resCache ResolutionCache
+var (
+	resCache  ResolutionCache
+	onceCache sync.Once
+)
 
-func init() {
-	resCache = initResolutionCache()
+// initResolutionCache initializes the URI resolution cache. To be wrapped in a sync.Once.Do call.
+func initResolutionCache() {
+	resCache = defaultResolutionCache()
 }
 
-// initResolutionCache initializes the URI resolution cache
-func initResolutionCache() ResolutionCache {
+func defaultResolutionCache() ResolutionCache {
 	return &simpleCache{store: map[string]interface{}{
 		"http://swagger.io/v2/schema.json":       MustLoadSwagger20Schema(),
 		"http://json-schema.org/draft-04/schema": MustLoadJSONSchemaDraft04(),

--- a/expander.go
+++ b/expander.go
@@ -211,6 +211,7 @@ func baseForRoot(root interface{}, cache ResolutionCache) string {
 		normalizedBase := normalizeAbsPath(base)
 		debugLog("setting root doc in cache at: %s", normalizedBase)
 		if cache == nil {
+			onceCache.Do(initResolutionCache)
 			cache = resCache
 		}
 		cache.Set(normalizedBase, root)

--- a/expander_test.go
+++ b/expander_test.go
@@ -383,7 +383,7 @@ func TestExpandResponseWithRoot_CircularRefs(t *testing.T) {
 		path := rootDoc.Paths.Paths["/api/v1/getx"]
 		resp := path.Post.Responses.StatusCodeResponses[200]
 
-		resCache = initResolutionCache()
+		resCache = defaultResolutionCache()
 
 		// during first response expand, refs are getting expanded,
 		// so the following expands cannot properly resolve them w/o the document.
@@ -1039,8 +1039,10 @@ func TestSchemaExpansion(t *testing.T) {
 }
 
 func TestDefaultResolutionCache(t *testing.T) {
+	jsonSchema := MustLoadJSONSchemaDraft04()
+	swaggerSchema := MustLoadSwagger20Schema()
 
-	cache := initResolutionCache()
+	cache := defaultResolutionCache()
 
 	sch, ok := cache.Get("not there")
 	assert.False(t, ok)
@@ -1236,7 +1238,7 @@ func TestResolveRemoteRef_FromFragment(t *testing.T) {
 		var tgt Schema
 		ref, err := NewRef(server.URL + "/refed.json#/definitions/pet")
 		if assert.NoError(t, err) {
-			resolver := &schemaLoader{root: rootDoc, cache: initResolutionCache(), loadDoc: jsonDoc}
+			resolver := &schemaLoader{root: rootDoc, cache: defaultResolutionCache(), loadDoc: jsonDoc}
 			if assert.NoError(t, resolver.Resolve(&ref, &tgt, "")) {
 				assert.Equal(t, []string{"id", "name"}, tgt.Required)
 			}

--- a/operation.go
+++ b/operation.go
@@ -25,7 +25,6 @@ import (
 )
 
 func init() {
-	// gob.Register(map[string][]interface{}{})
 	gob.Register(map[string]interface{}{})
 	gob.Register([]interface{}{})
 }

--- a/schema_loader.go
+++ b/schema_loader.go
@@ -257,6 +257,7 @@ func defaultSchemaLoader(
 	context *resolverContext) (*schemaLoader, error) {
 
 	if cache == nil {
+		onceCache.Do(initResolutionCache)
 		cache = resCache
 	}
 	if expandOptions == nil {

--- a/spec.go
+++ b/spec.go
@@ -14,7 +14,9 @@
 
 package spec
 
-import "encoding/json"
+import (
+	"encoding/json"
+)
 
 //go:generate curl -L --progress -o ./schemas/v2/schema.json http://swagger.io/v2/schema.json
 //go:generate curl -L --progress  -o ./schemas/jsonschema-draft-04.json http://json-schema.org/draft-04/schema
@@ -27,16 +29,6 @@ const (
 	// JSONSchemaURL the url for the json schema schema
 	JSONSchemaURL = "http://json-schema.org/draft-04/schema#"
 )
-
-var (
-	jsonSchema    *Schema
-	swaggerSchema *Schema
-)
-
-func init() {
-	jsonSchema = MustLoadJSONSchemaDraft04()
-	swaggerSchema = MustLoadSwagger20Schema()
-}
 
 // MustLoadJSONSchemaDraft04 panics when Swagger20Schema returns an error
 func MustLoadJSONSchemaDraft04() *Schema {


### PR DESCRIPTION
The point with this PR is to avoid unnecessary memory requirements on packages importing this package because of some dependency but do not actually use its full functionality.

Most memory initialization is required by the expander so let’s allocate it only when required.
 
* moved default cache initialization from init() to on-demand initializer wrapped in sync.Once.Do
* removed unused jsonSchema & swaggerSchema initialized globals
* replaced PathLoader init() by lazy var initialization

Signed-off-by: Frederic BIDON <fredbi@yahoo.com>