### PR TITLE
Get root from cache by a correct key

### DIFF
--- a/expander.go
+++ b/expander.go
@@ -200,11 +200,11 @@ func ExpandSpec(spec *Swagger, options *ExpandOptions) error {
 	return nil
 }
 
+const rootBase = "root"
 // baseForRoot loads in the cache the root document and produces a fake "root" base path entry
 // for further $ref resolution
 func baseForRoot(root interface{}, cache ResolutionCache) string {
 	// cache the root document to resolve $ref's
-	const rootBase = "root"
 	if root != nil {
 		base, _ := absPath(rootBase)
 		normalizedBase := normalizeAbsPath(base)

--- a/fixtures/more_circulars/resp.json
+++ b/fixtures/more_circulars/resp.json
@@ -1,0 +1,51 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "description": "TestSwagger",
+    "version": "1.0",
+    "title": "Test"
+  },
+  "host": "127.0.0.1:8443",
+  "basePath": "/",
+  "schemes": [
+    "https"
+  ],
+  "paths": {
+    "/api/v1/getx": {
+      "post": {
+        "operationId": "getx",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "Operation successful",
+            "schema": {
+              "$ref": "#/definitions/MyObj"
+            }
+          }
+        },
+        "security": []
+      }
+    }
+  },
+  "definitions": {
+    "MyObj": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "child-objects": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/MyObj"
+          }
+        }
+      }
+    }
+  }
+}

--- a/schema_loader.go
+++ b/schema_loader.go
@@ -149,7 +149,15 @@ func (r *schemaLoader) load(refURL *url.URL) (interface{}, url.URL, bool, error)
 	toFetch := *refURL
 	toFetch.Fragment = ""
 
-	normalized := normalizeAbsPath(toFetch.String())
+	var err error
+	path := toFetch.String()
+	if path == rootBase {
+		path, err = absPath(rootBase)
+		if err != nil {
+			return nil, url.URL{}, false, err
+		}
+	}
+	normalized := normalizeAbsPath(path)
 
 	data, fromCache := r.cache.Get(normalized)
 	if !fromCache {


### PR DESCRIPTION
During root expansion without base, the doc gets loaded by fake absolute path key to the cache, but during resolve it tries to load the doc with just "root" key.

this contributes to https://github.com/go-openapi/spec/issues/95