### PR TITLE
bugfix: remove type from body parameter object.

### DIFF
--- a/parameter.go
+++ b/parameter.go
@@ -39,8 +39,7 @@ func PathParam(name string) *Parameter {
 
 // BodyParam creates a body parameter
 func BodyParam(name string, schema *Schema) *Parameter {
-	return &Parameter{ParamProps: ParamProps{Name: name, In: "body", Schema: schema},
-		SimpleSchema: SimpleSchema{Type: "object"}}
+	return &Parameter{ParamProps: ParamProps{Name: name, In: "body", Schema: schema}}
 }
 
 // FormDataParam creates a body parameter

--- a/parameters_test.go
+++ b/parameters_test.go
@@ -142,16 +142,16 @@ func TestParameterSerialization(t *testing.T) {
 
 	assertSerializeJSON(t,
 		BodyParam("", schema),
-		`{"type":"object","in":"body","schema":{"properties":{"name":{"type":"string"}}}}`)
+		`{"in":"body","schema":{"properties":{"name":{"type":"string"}}}}`)
 
 	assertSerializeJSON(t,
 		BodyParam("", refSchema),
-		`{"type":"object","in":"body","schema":{"$ref":"Cat"}}`)
+		`{"in":"body","schema":{"$ref":"Cat"}}`)
 
 	// array body param
 	assertSerializeJSON(t,
 		BodyParam("", ArrayProperty(RefProperty("Cat"))),
-		`{"type":"object","in":"body","schema":{"type":"array","items":{"$ref":"Cat"}}}`)
+		`{"in":"body","schema":{"type":"array","items":{"$ref":"Cat"}}}`)
 
 }
 


### PR DESCRIPTION
Hello, as i understand.

When parameter object's in is `body`, should not has property `type`.