### PR TITLE
Fix `ResolveParameterWithBase` bug (which is broken now)

### DIFF
--- a/expander.go
+++ b/expander.go
@@ -81,9 +81,13 @@ func ResolveParameterWithBase(root interface{}, ref Ref, opts *ExpandOptions) (*
 	if err != nil {
 		return nil, err
 	}
+	specBasePath := ""
+	if opts != nil && opts.RelativeBase != "" {
+		specBasePath, _ = absPath(opts.RelativeBase)
+	}
 
 	result := new(Parameter)
-	if err := resolver.Resolve(&ref, result, ""); err != nil {
+	if err := resolver.Resolve(&ref, result, specBasePath); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -101,8 +105,13 @@ func ResolveResponseWithBase(root interface{}, ref Ref, opts *ExpandOptions) (*R
 		return nil, err
 	}
 
+	specBasePath := ""
+	if opts != nil && opts.RelativeBase != "" {
+		specBasePath, _ = absPath(opts.RelativeBase)
+	}
+
 	result := new(Response)
-	if err := resolver.Resolve(&ref, result, ""); err != nil {
+	if err := resolver.Resolve(&ref, result, specBasePath); err != nil {
 		return nil, err
 	}
 	return result, nil

--- a/fixtures/expansion/crossFileRef.json
+++ b/fixtures/expansion/crossFileRef.json
@@ -1,0 +1,22 @@
+{
+  "paths": {
+    "/pets": {
+      "get": {
+        "parameters": [
+          {
+            "$ref": "./all-the-things.json#/parameters/idParam"
+          }
+        ]
+      }
+    },
+    "/": {
+      "get": {
+        "responses": {
+          "200": {
+            "$ref": "./all-the-things.json#/responses/anotherPet"
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
When the `opts` is set with `RelativeBase` set, current `ResolveParameterWithBase` will just fail. Referring to the implementation of `ResolveWithBase`, adding the missing part to make it work.