### PR TITLE
fixed case of circular references

### DIFF
--- a/fixtures/bugs/102/fixture-102.json
+++ b/fixtures/bugs/102/fixture-102.json
@@ -1,0 +1,71 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "description": "My API",
+    "version": "1.0.0",
+    "title": "my api",
+    "contact": {
+      "email": "me@myorg.com"
+    },
+    "license": {
+      "name": "my org"
+    }
+  },
+  "host": "127.0.0.1",
+  "basePath": "/",
+  "tags": [],
+  "schemes": [
+    "https"
+  ],
+  "paths": {
+    "/api/v1/endpoint": {
+      "post": {
+        "summary": "my endpoint",
+        "description": "Accessible to . ",
+        "operationId": "ep1",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+
+        ],
+        "responses": {
+          "200": {
+            "description": "Operation successful",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        },
+        "security": []
+      }
+    }
+  },
+  "definitions": {
+    "Error": {
+      "type": "object",
+      "properties": {
+        "errorCode": {
+          "type": "string",
+          "format": "string"
+        },
+        "errorMessage": {
+          "type": "string",
+          "format": "string"
+        },
+        "warning": {
+          "type": "string"
+        },
+        "child-errors": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Error"
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Covers case with ExpandResponseWithRoot and ExpandParameterWithRoot

* acknowledged github.com/go-openapi/validate#102 is fixed
* extended this use case of circular references to the "WithRoot" functions and fixed issues with those

* fixes #95

Signed-off-by: Frederic BIDON <fredbi@yahoo.com>