### PR TITLE
go-swagger throws error on Windows if application path contains parentheses 

### DIFF
--- a/schema_loader.go
+++ b/schema_loader.go
@@ -168,7 +168,14 @@ func (r *schemaLoader) load(refURL *url.URL) (interface{}, url.URL, bool, error)
 	normalized := normalizeBase(pth)
 	debugLog("loading doc from: %s", normalized)
 
-	data, fromCache := r.cache.Get(normalized)
+	unescaped, err := url.PathUnescape(normalized)
+	if err != nil {
+		return nil, url.URL{}, false, err
+	}
+
+	u := url.URL{Path: unescaped}
+
+	data, fromCache := r.cache.Get(u.RequestURI())
 	if fromCache {
 		return data, toFetch, fromCache, nil
 	}


### PR DESCRIPTION
Possible fix for issue: go-swagger throws error on Windows if application path contains parentheses #145