### PR TITLE
Fix failed windows tests that depends on cwd

### DIFF
--- a/normalizer_test.go
+++ b/normalizer_test.go
@@ -14,6 +14,24 @@ import (
 
 const windowsOS = "windows"
 
+// only used for windows
+var currentDriveLetter = getCurrentDrive()
+
+// get the current drive letter in lowercase on windows that the test is running
+func getCurrentDrive() string {
+	if runtime.GOOS != windowsOS {
+		return ""
+	}
+	p, err := filepath.Abs("/")
+	if err != nil {
+		panic(err)
+	}
+	if len(p) == 0 {
+		panic("current windows drive letter is empty")
+	}
+	return strings.ToLower(string(p[0]))
+}
+
 func TestNormalizer_NormalizeURI(t *testing.T) {
 	type testNormalizePathsTestCases []struct {
 		refPath    string
@@ -299,7 +317,7 @@ func TestNormalizer_NormalizeBase(t *testing.T) {
 		{
 			// path clean
 			Base:     "///folder//subfolder///file.json/",
-			Expected: "file:///c:/folder/subfolder/file.json",
+			Expected: "file:///" + currentDriveLetter + ":/folder/subfolder/file.json",
 			Windows:  true,
 		},
 		{
@@ -326,7 +344,7 @@ func TestNormalizer_NormalizeBase(t *testing.T) {
 		{
 			// handling dots (3/6): valid, cleaned to /c:/ on windows
 			Base:     "/..",
-			Expected: "file:///c:",
+			Expected: "file:///" + currentDriveLetter + ":",
 			Windows:  true,
 		},
 		{
@@ -359,7 +377,7 @@ func TestNormalizer_NormalizeBase(t *testing.T) {
 		// windows-only cases
 		{
 			Base:     "/base/sub/file.json",
-			Expected: "file:///c:/base/sub/file.json", // on windows, filepath.Abs("/a/b") prepends the "c:" drive
+			Expected: "file:///" + currentDriveLetter + ":/base/sub/file.json", // on windows, filepath.Abs("/a/b") prepends the "c:" drive
 			Windows:  true,
 		},
 		{


### PR DESCRIPTION
Signed-off-by: Youyuan Wu <youyuanwu@outlook.com>

Failed tests on master:
```
--- FAIL: TestNormalizer_NormalizeBase (0.00s)
    --- FAIL: TestNormalizer_NormalizeBase//base/sub/file.json (0.00s)
        normalizer_test.go:[41](https://github.com/go-openapi/spec/runs/7816924392?check_suite_focus=true#step:4:42)8: 
            	Error Trace:	normalizer_test.go:418
            	Error:      	Not equal: 
            	            	expected: "file:///c:/base/sub/file.json"
            	            	actual  : "file:///d:/base/sub/file.json"
            	            	
            	            	Diff:
            	            	--- Expected
            	            	+++ Actual
            	            	@@ -1 +1 @@
            	            	-file:///c:/base/sub/file.json
            	            	+file:///d:/base/sub/file.json
            	Test:       	TestNormalizer_NormalizeBase//base/sub/file.json
            	Messages:   	for base "/base/sub/file.json"
    --- FAIL: TestNormalizer_NormalizeBase//.. (0.00s)
        normalizer_test.go:418: 
            	Error Trace:	normalizer_test.go:418
            	Error:      	Not equal: 
            	            	expected: "file:///c:"
            	            	actual  : "file:///d:"
            	            	
            	            	Diff:
            	            	--- Expected
            	            	+++ Actual
            	            	@@ -1 +1 @@
            	            	-file:///c:
            	            	+file:///d:
            	Test:       	TestNormalizer_NormalizeBase//..
            	Messages:   	for base "/.."
    --- FAIL: TestNormalizer_NormalizeBase////folder//subfolder///file.json/ (0.00s)
        normalizer_test.go:418: 
            	Error Trace:	normalizer_test.go:418
            	Error:      	Not equal: 
            	            	expected: "file:///c:/folder/subfolder/file.json"
            	            	actual  : "file:///d:/folder/subfolder/file.json"
            	            	
            	            	Diff:
            	            	--- Expected
            	            	+++ Actual
            	            	@@ -1 +1 @@
            	            	-file:///c:/folder/subfolder/file.json
            	            	+file:///d:/folder/subfolder/file.json
            	Test:       	TestNormalizer_NormalizeBase////folder//subfolder///file.json/
            	Messages:   	for base "///folder//subfolder///file.json/"
```
The cause of failure is that the tests were running in D:/ drive in stead of C:/ drive in github action.
Not sure the filepath.abs() changed behaviour or not. i.e. if it always returns C:/.

The fix is to change tests to have expected value matching the current drive.