### PR TITLE
ci: fixed codecov upload

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -37,21 +37,21 @@ jobs:
         go_version: ['oldstable', 'stable' ]
 
     steps:
-    - name: Run unit tests
-      uses: actions/setup-go@v5
+    - uses: actions/setup-go@v5
       with:
         go-version: '${{ matrix.go_version }}'
         check-latest: true
         cache: true
 
     - uses: actions/checkout@v4
-
-    - run: go test -v -race -coverprofile="coverage-${{ matrix.os }}.${{ matrix.go_version }}.out" -covermode=atomic -coverpkg=$(go list)/... ./...
+    - name: Run unit tests
+      shell: bash
+      run: go test -v -race -coverprofile="coverage-${{ matrix.os }}.${{ matrix.go_version }}.out" -covermode=atomic -coverpkg=$(go list)/... ./...
 
     - name: Upload coverage to codecov
       uses: codecov/codecov-action@v5
       with:
         files: './coverage-${{ matrix.os }}.${{ matrix.go_version }}.out'
-        flags: '${{ matrix.go_version }},${{ matrix.os }}'
+        flags: '${{ matrix.go_version }}-${{ matrix.os }}'
         fail_ci_if_error: false
         verbose: true


### PR DESCRIPTION
Fixed broken test coverage upload to codecov with codecov-action@v5.

    * fixed tokenless upload (now supported with codecov v5)
    * fixed flags for codecov
    * fixed coverage for windows (now use bash instead of powershell)