### PR TITLE
chore(ci): run contributors workflow monthly instead of weekly

### DIFF
--- a/.github/workflows/contributors.yml
+++ b/.github/workflows/contributors.yml
@@ -2,7 +2,7 @@ name: Contributors
 
 on:
   schedule:
-    - cron: '18 4 * * 6'
+    - cron: '49 4 1 * *'
 
   workflow_dispatch:
 


### PR DESCRIPTION
Switches the `contributors.yml` schedule from weekly (`18 4 * * 6`, Saturdays) to monthly: the 1st of each month at 04:49 UTC (`'49 4 1 * *'`).

Weekly runs were a nice tribute to past contributors, but these days they mostly bump maintainer activity, so once a month is enough.

🤖 Generated with [Claude Code](https://claude.com/claude-code)