### PR TITLE
feat: add QUERY method (RFC 10008) to PathItemProps

### DIFF
--- a/expander.go
+++ b/expander.go
@@ -404,6 +404,7 @@ func expandPathItem(pathItem *PathItem, resolver *schemaLoader, basePath string)
 		pathItem.Post,
 		pathItem.Patch,
 		pathItem.Delete,
+		pathItem.Query,
 	}
 	for _, op := range ops {
 		if err := expandOperation(op, resolver, basePath); resolver.shouldStopOnError(err) {

--- a/path_item.go
+++ b/path_item.go
@@ -19,6 +19,7 @@ type PathItemProps struct {
 	Options    *Operation  `json:"options,omitempty"`
 	Head       *Operation  `json:"head,omitempty"`
 	Patch      *Operation  `json:"patch,omitempty"`
+	Query      *Operation  `json:"query,omitempty"`
 	Parameters []Parameter `json:"parameters,omitempty"`
 }
 

--- a/path_item_test.go
+++ b/path_item_test.go
@@ -38,6 +38,9 @@ var pathItem = PathItem{ //nolint:gochecknoglobals // test fixture
 		Patch: &Operation{
 			OperationProps: OperationProps{Description: "patch operation description"},
 		},
+		Query: &Operation{
+			OperationProps: OperationProps{Description: "query operation description"},
+		},
 		Parameters: []Parameter{
 			{
 				ParamProps: ParamProps{In: "path"},
@@ -56,6 +59,7 @@ const pathItemJSON = `{
 	"options": { "description": "options operation description" },
 	"head": { "description": "head operation description" },
 	"patch": { "description": "patch operation description" },
+	"query": { "description": "query operation description" },
 	"parameters": [{"in":"path"}]
 }`
 


### PR DESCRIPTION
## Change type

🆕 New feature or enhancement

## Short description

Add a `Query` operation field to `PathItemProps` so the HTTP `QUERY` method ([RFC 10008](https://www.rfc-editor.org/rfc/rfc10008.html)) can be represented and round-tripped.

## Fixes

Fixes #288 

## Full description

`QUERY` is a safe, idempotent, cacheable HTTP method that carries a request body (semantics per [RFC 9110](https://www.rfc-editor.org/rfc/rfc9110.html)), and it is a valid Path Item operation in OpenAPI 3.2. `PathItemProps` previously had no field to hold it, so a QUERY endpoint could not be modeled.

Changes:
- `path_item.go`: add `Query *Operation` with the `query` JSON tag. The struct (de)serializes via reflection over its fields, so no changes to `MarshalJSON` / `UnmarshalJSON` / `JSONLookup` are needed.
- `expander.go`: include `pathItem.Query` in the operation slice walked during `$ref` expansion.
- `path_item_test.go`: extend the `TestIntegrationPathItem` round-trip fixture to cover `query`.

Scope note: this package models Swagger/OpenAPI 2.0, where `query` is not a formally defined Path Item field. The field is additive, marshals cleanly to the expected `"query": { ... }` output, and unblocks downstream tooling ([swaggo/swag#2193](https://github.com/swaggo/swag/issues/2193)). Happy to adjust if maintainers prefer a different approach — see the discussion in #287.

## Checklist

- [x] I have signed all my commits with my name and email (see [DCO](https://github.com/apps/dco)). **This does not require a PGP-signed commit**
- [x] I have rebased and squashed my work, so only one commit remains
- [x] I have added tests to cover my changes.
- [x] I have properly enriched go doc comments in code.
- [x] I have properly documented any breaking change. (None — additive field.)
