### PR TITLE
test(normalizer): fix the escaped-path base case failing on windows

### DIFF
--- a/normalizer_canonical_test.go
+++ b/normalizer_canonical_test.go
@@ -173,13 +173,6 @@ func TestNormalizer_CanonicalBase(t *testing.T) {
 			base:     "https://example.com/base/spec.json#/definitions/x",
 			expected: "https://example.com/base/spec.json",
 		},
-		{
-			name: "escaped path rendering",
-			rule: `"%2F" decodes to "/", and the escaped form has no leading slash to render, ` +
-				`so it used to come out as the authority of "file://%2F"`,
-			base:     "%2F",
-			expected: "file:///",
-		},
 	}
 
 	for _, test := range tests {
@@ -197,6 +190,34 @@ func TestNormalizer_CanonicalBase(t *testing.T) {
 				"normalizing %q again changed it", canonical)
 		})
 	}
+}
+
+// TestNormalizer_EscapedPathRendering covers the rendering defect that produced an unparseable
+// base: normalizeBase("%2F") returned "file://%2F".
+//
+// url.Parse reads "%2F" as the path "/" spelled "%2F", and url.URL.String renders RawPath
+// whenever it still decodes to Path - here a spelling with no leading slash, so what is left
+// reads as an authority. forgetSpelling drops RawPath once Path has been rewritten.
+//
+// The expectation is written against normalizeBase("/") rather than a literal, because a
+// relative base is anchored to the working directory: "file:///" on unix, "file:///c:" or
+// whichever drive the tests run from on windows.
+func TestNormalizer_EscapedPathRendering(t *testing.T) {
+	t.Parallel()
+
+	const escapedSlash = "%2F"
+
+	canonical := normalizeBase(escapedSlash)
+	assert.EqualT(t, normalizeBase("/"), canonical, "the escaped spelling of the root must normalize like the plain one")
+	assert.NotEqualT(t, "file://"+escapedSlash, canonical, "the escaped path was rendered as an authority")
+
+	_, err := parseURL(canonical)
+	require.NoErrorf(t, err, "normalizing %q yielded %q, which does not parse", escapedSlash, canonical)
+
+	ref := MustCreateRef(canonical)
+	assert.EqualTf(t, canonical, ref.String(),
+		"%q is not a fixpoint of jsonreference's canonicalization", canonical)
+	assert.EqualTf(t, canonical, normalizeBase(canonical), "normalizing %q again changed it", canonical)
 }
 
 // TestNormalizer_EscapedSlashIsDecoded records a rule that is not ours to change here.


### PR DESCRIPTION
TestNormalizer_CanonicalBase/escaped_path_rendering expected normalizeBase("%2F") to be "file:///". A base carrying no scheme is anchored to the working directory, so on windows it comes out as "file:///d:", or whichever drive the tests run from.

The case moves out of the table into TestNormalizer_EscapedPathRendering, which compares normalizeBase("%2F") against normalizeBase("/") rather than a literal: both spell the root and both are anchored the same way, on either platform. It also asserts what the defect actually was, that the result is neither "file://%2F" nor something parseURL rejects.

## Change type

Please select: 🆕 New feature or enhancement|🔧 Bug fix'|📃 Documentation update

## Short description
<!-- Please provide a short description of your change -->

## Fixes
<!-- 
Example:
* fixes #123

Avoid cross-repository fixes, e.g.
* fixes go-openapi/spec#123

Prefer instead:
* contributes go-openapi/spec#123

This means will be solved, but when releases and dependencies updates have been carried out
-->

## Full description
<!-- If needed, please add here more details about your implementation etc -->

<!-- Since this is a bug fix, try your best not to mix this change with extra features or potentially breaking changes -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you don't qualify for all of the below check list items, please mark your PR in a draft status, so it may be discussed or reviewed with lighter requirements. -->

* [ ] I have signed all my commits with my name and email (see [DCO](https://github.com/apps/dco). **This does not require a PGP-signed commit**
* [ ] I have rebased and squashed my work, so only one commit remains
* [ ] I have added tests to cover my changes.
* [ ] I have properly enriched go doc comments in code.
* [ ] I have properly documented any breaking change.
